### PR TITLE
fix(sensor): Use thread-safe hass.add_job in time interval callback

### DIFF
--- a/custom_components/openaq/sensor.py
+++ b/custom_components/openaq/sensor.py
@@ -144,7 +144,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
         unsub = async_track_time_interval(
             hass,
-            lambda now: hass.async_create_task(coordinator_latest.async_request_refresh()),
+            lambda now: hass.add_job(coordinator_latest.async_request_refresh),
             SCAN_INTERVAL_LATEST,
         )
         entry.async_on_unload(unsub)


### PR DESCRIPTION
This PR resolves a `RuntimeError` caused by a thread-safety violation.

The integration was calling `hass.async_create_task` from within the callback of `async_track_time_interval`. Since `async_track_time_interval` runs its callback in a background thread, this causes a thread-safety error, as `hass.async_create_task` is not thread-safe.

This change replaces the non-thread-safe `hass.async_create_task` with `hass.add_job`, which is the correct, thread-safe function for scheduling a coroutine on the event loop from another thread.

The syntax is also updated to pass the `async_request_refresh` function reference **without parentheses**. This ensures `hass.add_job` schedules the function to be run on the main loop, rather than it being called immediately in the background thread.

This fixes the following error seen in the logs:

```
Logger: homeassistant.helpers.frame
Source: helpers/frame.py:350
Detected that custom integration 'openaq' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt.
...
RuntimeError: Detected that custom integration 'openaq' calls hass.async_create_task from a thread other than the event loop...
```

Fixes #1 