### PR TITLE
Fix unsafe task scheduling causing thread warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.3
+- Fixed periodic refresh logic
+- Removed unsafe async task scheduling
+
+## 0.1.2
+- Initial release

--- a/custom_components/openaq/manifest.json
+++ b/custom_components/openaq/manifest.json
@@ -8,6 +8,6 @@
 	"iot_class": "cloud_polling",
 	"issue_tracker": "https://github.com/zenguru84/ha-openaq/issues",
 	"requirements": ["aiohttp"],
-	"version": "0.1.2"
+	"version": "0.1.3"
 }
 

--- a/custom_components/openaq/sensor.py
+++ b/custom_components/openaq/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -128,6 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             update_method=lambda u=url_meta: _fetch_json(session, u, headers),
             update_interval=SCAN_INTERVAL_META,
         )
+
         coordinator_latest = DataUpdateCoordinator(
             hass,
             _LOGGER,
@@ -141,13 +141,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
         meta_root = _meta_root(coordinator_meta.data)
         location_name = meta_root.get("name") or f"Station {location_id}"
-
-        unsub = async_track_time_interval(
-            hass,
-            lambda now: hass.async_create_task(coordinator_latest.async_request_refresh()),
-            SCAN_INTERVAL_LATEST,
-        )
-        entry.async_on_unload(unsub)
 
         wanted_params = [
             ("pm1",  "PM1",   SensorDeviceClass.PM1,   CONCENTRATION_MICROGRAMS_PER_CUBIC_METER),


### PR DESCRIPTION
### Summary
This PR fixes an issue where the OpenAQ integration did not reliably refresh data at the expected 5-minute interval.

### Fixes #1 
- Removed unsafe callback using `hass.async_create_task`
- Switched to pure DataUpdateCoordinator refresh logic
- Removed redundant async_track_time_interval block
- Cleanup and stability improvements

### Version
Bumps version to **0.1.3**.